### PR TITLE
Update image tag to v2.0.1

### DIFF
--- a/kubernetes/kustomization.yml
+++ b/kubernetes/kustomization.yml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: peraltamorena/go-con-coche-app
-    newTag: sha-b6ba9af
+    newTag: v2.0.1
 
 namePrefix: go-con-coche-
 


### PR DESCRIPTION
### ⚠️ Merging this PR will trigger a deployment to the Kubernetes cluster using ArgoCD. ⚠️ 

## Summary
Automated PR to update the Kubernetes kustomization file with the new image tag from the latest release.

## Changes
- Updated `kubernetes/kustomization.yml` image tag to ``
- This corresponds to the Docker image: `raelga/ff5-dreamroute:v2.0.1`

## Release Workflow
- Triggered by release workflow run: https://github.com/morenaperalta/GoConcocheTest/actions/runs/18261185807
- Release tag: `v2.0.1`